### PR TITLE
annotationProcessor 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,10 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-gateway:4.2.1")
     implementation("io.jsonwebtoken:jjwt:0.12.6")
 
-    compileOnly 'org.projectlombok:lombok'
+    compileOnly("org.projectlombok:lombok:1.18.38")
 
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
-    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor:3.4.5")
+    annotationProcessor("org.projectlombok:lombok:1.18.38")
 
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
 
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor 'org.projectlombok:lombok'
+
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
### 문제 원인 요약

Gradle로 compileJava를 실행할 때 error: cannot find symbol이 발생하는데, 소스코드에는 분명히 @Getter, @Setter가 붙어 있음에도 getGranted() 등 Lombok이 생성해주는 메서드를 못 찾는다는 오류입니다.

이 경우, Lombok 어노테이션이 제대로 컴파일 타임에 처리되지 않아 메서드가 생성되지 않은 것이 주요 원인입니다. 이는 Gradle 빌드 설정과 Lombok의 annotation processing 설정이 누락되어 있을 때 자주 발생합니다.

### 해결 방법
Lombok 의존성은 추가했지만, annotationProcessor 의존성이 누락된 경우
implementation 'org.projectlombok:lombok'만 추가하면 IDE에서는 동작해도, Gradle 빌드(특히 CLI)에서는 동작하지 않습니다. 반드시 annotationProcessor도 추가해야 합니다.

---

- 누락된 의존성 추가