### PR TITLE
[#13] 라우팅 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,22 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.google.cloud.tools.jib' version '3.4.5'
+}
+
+
+jib {
+    from {
+        image = "openjdk:21-jdk-slim"
+    }
+    to {
+        image = project.findProperty("dockerImageName")
+        tags = ["latest"]
+        auth {
+            username = project.findProperty("dockerUsername")
+            password = project.findProperty("dockerPassword")
+        }
+    }
 }
 
 group = 'com.baedal'

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,7 +20,7 @@ spring:
     gateway:
       routes:
         - id: owner
-          uri: http://localhost:8087
+          uri: http://owner:8087
           predicates:
             - Path=/api/owner/**
           filters:
@@ -29,7 +29,7 @@ spring:
                 role: OWNER
 
         - id: customer
-          uri: http://localhost:8088
+          uri: http://customer:8088
           predicates:
             - Path=/api/customer/**
           filters:
@@ -38,7 +38,7 @@ spring:
                 role: CUSTOMER
 
         - id: rider
-          uri: http://localhost:8089
+          uri: http://rider:8089
           predicates:
             - Path=/api/rider/**
           filters:
@@ -47,32 +47,32 @@ spring:
                 role: RIDER
 
         - id: store
-          uri: http://localhost:8081
+          uri: http://store:8081
           predicates:
             - Path=/api/store/**
 
 
         - id: product
-          uri: http://localhost:8082
+          uri: http://product:8082
           predicates:
             - Path=/api/product/**
 
         - id: cart
-          uri: http://localhost:8083
+          uri: http://cart:8083
           predicates:
             - Path=/api/cart/**
 
         - id: order
-          uri: http://localhost:8084
+          uri: http://order:8084
           predicates:
             - Path=/api/order/**
 
         - id: payment
-          uri: http://localhost:8085
+          uri: http://payment:8085
           predicates:
             - Path=/api/payment/**
 
         - id: review
-          uri: http://localhost:8086
+          uri: http://review:8086
           predicates:
             - Path=/api/review/**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,10 @@
 spring:
   application:
     name: gateway
+  profiles:
+    active: local
 
   output:
     ansi:
       enabled: always
+


### PR DESCRIPTION
도메인 별 라우팅 추가하였습니다.

게이트웨이 -> 8080
매장 -> 8081 
상품 -> 8082
장바구니 -> 8083
주문 -> 8084
결제 -> 8085
리뷰 -> 8086
점주 -> 8087
고객 -> 8088
라이더 -> 8089


각 도메인 별 요청 주소를 아래와 같이 통일하기 위해 기존 StripPrefix 설정을 제거하였습니다.
http://[게이트웨이]:8080/api/[도메인]/v0/[요청]


각 도메인은 아래와 같은 주소를 설정해야합니다.
http://[주소]:[포트]/api/[도메인]/v0/[요청]